### PR TITLE
Offnao bug unkown cotire cmake

### DIFF
--- a/utils/offnao/CMakeLists.txt
+++ b/utils/offnao/CMakeLists.txt
@@ -90,12 +90,6 @@ SET(OFFNAO_RES
    resources/visualiser_resources.qrc
 )
 
-set (CMAKE_MODULE_PATH "/home/ubuntu/rUNSWift/CMake")
-INCLUDE(cotire)
-set (PNG_PNG_INCLUDE_DIR "${CTC_DIR}/png/include")
-set (PNG_LIBRARY "${CTC_DIR}/png/lib")
-set (QGLVIEWER_LIBRARY "$(RUNSWIFT_CHECKOUT_DIR)/ctc/sysroot_legacy/usr/include/QGLViewer")
-
 if( Qt4_FOUND )
    message([status] "Qt4 Found. Proceeding...")
 else( Qt4_FOUND )
@@ -103,6 +97,11 @@ else( Qt4_FOUND )
    SET(CMAKE_AUTOMOC ON)
    SET(CMAKE_INCLUDE_CURRENT_DIR ON)
    find_package(Qt4 4.8.6 REQUIRED QtGui QtXml)
+   set (CMAKE_MODULE_PATH "/home/ubuntu/rUNSWift/CMake")
+   INCLUDE(cotire)
+   set (PNG_PNG_INCLUDE_DIR "${CTC_DIR}/png/include")
+   set (PNG_LIBRARY "${CTC_DIR}/png/lib")
+   set (QGLVIEWER_LIBRARY "$(RUNSWIFT_CHECKOUT_DIR)/ctc/sysroot_legacy/usr/include/QGLViewer")
 endif( Qt4_FOUND )
 
 # build cxx files for resources

--- a/utils/offnao/CMakeLists.txt
+++ b/utils/offnao/CMakeLists.txt
@@ -90,6 +90,12 @@ SET(OFFNAO_RES
    resources/visualiser_resources.qrc
 )
 
+set (CMAKE_MODULE_PATH "/home/ubuntu/rUNSWift/CMake")
+INCLUDE(cotire)
+set (PNG_PNG_INCLUDE_DIR "${CTC_DIR}/png/include")
+set (PNG_LIBRARY "${CTC_DIR}/png/lib")
+set (QGLVIEWER_LIBRARY "$(RUNSWIFT_CHECKOUT_DIR)/ctc/sysroot_legacy/usr/include/QGLViewer")
+
 if( Qt4_FOUND )
    message([status] "Qt4 Found. Proceeding...")
 else( Qt4_FOUND )


### PR DESCRIPTION
When rUNSWift/bin/build_setup.sh is run, it includes Cotire and Qt4. However when attempting to build offnao on its own with its CMake files, they aren't loaded in.
This fix adds an if statement that detects if Qt4 is loaded, if Qt4 isn't loaded, it loads Qt4 and Cotire.